### PR TITLE
Possible confusion in RegisterPacketHandler

### DIFF
--- a/Network/Utilities/PacketHandlerMap.cs
+++ b/Network/Utilities/PacketHandlerMap.cs
@@ -142,9 +142,11 @@ namespace Network.Utilities
                 packetTypeToHandlerIdMap.Add(packetType, new Dictionary<object, int>());
             }
 
-            packetTypeToHandlerIdMap[packetType].Add(handlerInstance, UidGenerator.GenerateUid<int>());
+            var uid = UidGenerator.GenerateUid<int>();
+            
+            packetTypeToHandlerIdMap[packetType].Add(handlerInstance, uid);
 
-            packetIdToDelegateMethodMap.Add(UidGenerator.LastGeneratedUid<int>(), (handlerDelegate, handlerInstance));
+            packetIdToDelegateMethodMap.Add(uid, (handlerDelegate, handlerInstance));
         }
 
         /// <summary>


### PR DESCRIPTION
Everything goes well when one packet, then another and so on.. Problems begin when need to send two or more packets of the same type in parallel.

`UidGenerator.LastGeneratedUid<int>()` 

I have not tested this, but I think this function does not always return an ID that was created literally in the previous line of code. Most likely from here and exceptions of type KeyNotFoundException