### PR TITLE
Typo?

### DIFF
--- a/Network/RSA/SecureClientConnectionContainer.cs
+++ b/Network/RSA/SecureClientConnectionContainer.cs
@@ -30,7 +30,7 @@ namespace Network.RSA
         /// <param name="udpConnection">The UDP connection to use.</param>
         /// <param name="rsaPair">The local RSA key-pair.</param>
         internal SecureClientConnectionContainer(TcpConnection tcpConnection, UdpConnection udpConnection, RSAPair rsaPair)
-            : base(tcpConnection.IPRemoteEndPoint.Address.ToString(), tcpConnection.IPRemoteEndPoint.Port)
+            : base(tcpConnection, udpConnection)
         {
             RSAPair = rsaPair;
         }


### PR DESCRIPTION
Do I understand correctly that the call to this constructor is missing?
https://github.com/Toemsel/Network/blob/3f668dbaef1a6d338ca114b659950c368a4310f9/Network/ClientConnectionContainer.cs#L58-L63
Now the call goes directly to this constructor:
https://github.com/Toemsel/Network/blob/3f668dbaef1a6d338ca114b659950c368a4310f9/Network/ClientConnectionContainer.cs#L70

Was it on purpose or was it a typo?